### PR TITLE
Support replacements in descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ Run the binary with the following environment variables set:
 - `FEED_NAME`: A name for the rss feed
 - `MESSAGE_CONTENT`: Optional content for the message, useful for pinging users
   or roles with `<@user_id>` or `<@&role_id>`
-- `FEED_IS_HTML`: If this variable is set to any value, the feed description will be handled as html
+- `FEED_IS_HTML`: If this variable is set to any value, the feed description
+  will be handled as html
+- `RSS_REPLACEMENTS`: A list, separated by `:`, where each entry specifies a
+  replacement to apply on the embed's description with the syntax
+  `<search>/<replacement>`. Backslashes are used to escape `:` and `/`
+  characters.
 
 I recommend running the program periodically (i.e. with cron) to receive updates
 of the feed. To check for updates on multiple feeds at once, create multiple


### PR DESCRIPTION
The new `RSS_REPLACEMENTS` environment variable allows replacing strings in the descriptions of embeds. The variable's value is a list separated by `:` symbols and each entry has the syntax `<search>/<replacement>`. The special characters `/` and `:` can both be escaped with backslashes. For example: `https\:\/\/steamcommunity.com\/linkfilter\/?url=/` replaces steamcommunity URLs with the URL they redirect to.